### PR TITLE
Untested fix to allow Ethernet connectivity

### DIFF
--- a/src/main/java/at/maui/cheapcast/Utils.java
+++ b/src/main/java/at/maui/cheapcast/Utils.java
@@ -18,7 +18,6 @@ package at.maui.cheapcast;
 
 import android.content.Context;
 import android.content.res.AssetManager;
-import android.net.wifi.WifiManager;
 
 import java.io.BufferedReader;
 import java.io.IOException;
@@ -31,7 +30,7 @@ import java.net.SocketException;
 import java.util.Enumeration;
 
 public class Utils {
-    public static NetworkInterface getActiveNetworkInterface(WifiManager manager) {
+    public static NetworkInterface getActiveNetworkInterface() {
 
         Enumeration<NetworkInterface> interfaces = null;
         try {

--- a/src/main/java/at/maui/cheapcast/Utils.java
+++ b/src/main/java/at/maui/cheapcast/Utils.java
@@ -31,41 +31,30 @@ import java.net.SocketException;
 import java.util.Enumeration;
 
 public class Utils {
-    public static NetworkInterface getWifiNetworkInterface(WifiManager manager) {
+    public static NetworkInterface getActiveNetworkInterface(WifiManager manager) {
 
         Enumeration<NetworkInterface> interfaces = null;
         try {
-            //the WiFi network interface will be one of these.
             interfaces = NetworkInterface.getNetworkInterfaces();
         } catch (SocketException e) {
             return null;
         }
 
-        //We'll use the WiFiManager's ConnectionInfo IP address and compare it with
-        //the ips of the enumerated NetworkInterfaces to find the WiFi NetworkInterface.
-
-        //Wifi manager gets a ConnectionInfo object that has the ipAdress as an int
-        //It's endianness could be different as the one on java.net.InetAddress
-        //maybe this varies from device to device, the android API has no documentation on this method.
-        int wifiIP = manager.getConnectionInfo().getIpAddress();
-
-        //so I keep the same IP number with the reverse endianness
-        int reverseWifiIP = Integer.reverseBytes(wifiIP);
-
         while (interfaces.hasMoreElements()) {
-
             NetworkInterface iface = interfaces.nextElement();
-
-            //since each interface could have many InetAddresses...
             Enumeration<InetAddress> inetAddresses = iface.getInetAddresses();
-            while (inetAddresses.hasMoreElements()) {
-                InetAddress nextElement = inetAddresses.nextElement();
-                int byteArrayToInt = byteArrayToInt(nextElement.getAddress(),0);
 
-                //grab that IP in byte[] form and convert it to int, then compare it
-                //to the IP given by the WifiManager's ConnectionInfo. We compare
-                //in both endianness to make sure we get it.
-                if (byteArrayToInt == wifiIP || byteArrayToInt == reverseWifiIP) {
+            /* Check if we have a non-local address. If so, this is the active
+             * interface.
+             *
+             * This isn't a perfect heuristic: I have devices which this will
+             * still detect the wrong interface on, but it will handle the
+             * common cases of wifi-only and Ethernet-only.
+             */
+            while (inetAddresses.hasMoreElements()) {
+                InetAddress addr = inetAddresses.nextElement();
+
+                if (!(addr.isLoopbackAddress() || addr.isLinkLocalAddress())) {
                     return iface;
                 }
             }
@@ -80,7 +69,7 @@ public class Utils {
         while (addrs.hasMoreElements())
         {
             InetAddress addr = (InetAddress) addrs.nextElement();
-            if (addr instanceof Inet4Address)
+            if (addr instanceof Inet4Address && !addr.isLoopbackAddress())
                 return addr;
         }
         return null;

--- a/src/main/java/at/maui/cheapcast/service/CheapCastService.java
+++ b/src/main/java/at/maui/cheapcast/service/CheapCastService.java
@@ -104,7 +104,7 @@ public class CheapCastService extends Service {
         Log.d(LOG_TAG, "onCreate()");
 
         mWifiManager = (WifiManager)getSystemService(Context.WIFI_SERVICE);
-        mNetIf = Utils.getWifiNetworkInterface(mWifiManager);
+        mNetIf = Utils.getActiveNetworkInterface(mWifiManager);
 
         if(Build.VERSION.SDK_INT >= Build.VERSION_CODES.HONEYCOMB) {
             mPreferences = getSharedPreferences("cheapcast", MODE_PRIVATE | MODE_MULTI_PROCESS);

--- a/src/main/java/at/maui/cheapcast/service/CheapCastService.java
+++ b/src/main/java/at/maui/cheapcast/service/CheapCastService.java
@@ -104,7 +104,7 @@ public class CheapCastService extends Service {
         Log.d(LOG_TAG, "onCreate()");
 
         mWifiManager = (WifiManager)getSystemService(Context.WIFI_SERVICE);
-        mNetIf = Utils.getActiveNetworkInterface(mWifiManager);
+        mNetIf = Utils.getActiveNetworkInterface();
 
         if(Build.VERSION.SDK_INT >= Build.VERSION_CODES.HONEYCOMB) {
             mPreferences = getSharedPreferences("cheapcast", MODE_PRIVATE | MODE_MULTI_PROCESS);

--- a/src/main/java/at/maui/cheapcast/ssdp/SSDP.java
+++ b/src/main/java/at/maui/cheapcast/ssdp/SSDP.java
@@ -70,7 +70,7 @@ public class SSDP extends Thread {
         mContext = ctx;
         mWifiManager = (WifiManager)mContext.getSystemService(Context.WIFI_SERVICE);
 
-        mNetIf = Utils.getWifiNetworkInterface(mWifiManager);
+        mNetIf = Utils.getActiveNetworkInterface(mWifiManager);
     }
 
     @Override

--- a/src/main/java/at/maui/cheapcast/ssdp/SSDP.java
+++ b/src/main/java/at/maui/cheapcast/ssdp/SSDP.java
@@ -17,7 +17,6 @@
 package at.maui.cheapcast.ssdp;
 
 import android.content.Context;
-import android.net.wifi.WifiManager;
 import android.util.Log;
 import at.maui.cheapcast.Installation;
 import at.maui.cheapcast.Utils;
@@ -61,16 +60,13 @@ public class SSDP extends Thread {
 
     private NetworkInterface mNetIf;
 
-    private WifiManager mWifiManager;
     private Context mContext;
 
     private boolean mRunning = false;
 
     public SSDP(Context ctx) throws IOException {
         mContext = ctx;
-        mWifiManager = (WifiManager)mContext.getSystemService(Context.WIFI_SERVICE);
-
-        mNetIf = Utils.getActiveNetworkInterface(mWifiManager);
+        mNetIf = Utils.getActiveNetworkInterface();
     }
 
     @Override


### PR DESCRIPTION
At present, CheapCast only works if the Android device is using wi-fi for its network connectivity. This means that CheapCast can't be used on devices such as an Ouya if they're plugged into an Ethernet connection.

This PR theoretically fixes this. Unfortunately, I can't figure out how to compile CheapCast to actually test it, but I've tried the heuristic in the PR in a standalone app and it seems to detect the right address on both my phone and my Ouya. (It probably won't work properly on the ATV1200 I have floating around, since that has both Ethernet and wi-fi active at once, but one problem at a time.)

This may require some massaging before it's releasable, but the approach is sound. This would fix issue #8.
